### PR TITLE
Update Platform function

### DIFF
--- a/registerODCR.py
+++ b/registerODCR.py
@@ -145,9 +145,9 @@ def createCWAlarm(CapacityReservationId,RegionName):
     return response
 
 # this method helps to identify platform associated with the instance/image
-def describeImage(ImageId, client):
-    response = client.describe_images(ImageIds=[ImageId])
-    Platform = ''.join([a_dict['PlatformDetails'] for a_dict in response['Images']])
+def describePlatform(InstanceId, client):
+    response = client.describe_instances(InstanceIds=[InstanceId])
+    Platform = ''.join([a_dict['PlatformDetails'] for a_dict in response['Reservations'][0]['Instances']])
     return Platform
 
 # This method retruns Zonal reserve instance (ZRI) if exists or return null.

--- a/registerODCR.py
+++ b/registerODCR.py
@@ -194,7 +194,7 @@ def instanceNextToken(NextToken,client):
             if (instance['State']['Name'] == 'running' and InstanceLifecycle is None and CapacityReservationId is None and CapacityReservationSpecification != 0 and Tenancy == 'default' ):
                 InstanceId = instance['InstanceId']
                 ImageId =instance['ImageId'] 
-                Platform = describeImage(ImageId, client)
+                Platform = describePlatform(InstanceId, client)
                 if Platform is None or Platform =='':
                         print ("No Platform is set for the ImageId {}, instanceId {}".format(ImageId,InstanceId))
                 InstanceType = instance['InstanceType']


### PR DESCRIPTION
Update describePlatform function

*Problem Statement:* 
Since the  method needs to get the Platform information to create the ODRC which it gets after describing the AMI. This fails if the AMI is either deleted or made private. As a result we are not able to describe the AMI and fetch the Platform value.




*Description of changes:*
 Instead of using AMI to get the Platform value, we can use the PlatformDetails attribute in EC2.Client.describe_instances(**kwargs)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
